### PR TITLE
Generate params objects for Workato

### DIFF
--- a/tools/SdkGenerator/SdkGenerator/Languages/WorkatoSdk.cs
+++ b/tools/SdkGenerator/SdkGenerator/Languages/WorkatoSdk.cs
@@ -171,7 +171,8 @@ public class WorkatoSdk
                 sb.AppendLine($"          }}");
                 sb.AppendLine($"          result = {method}(\"{url}\", params).after_response do |code, body, headers|");
             }
-            
+
+            sb.AppendLine($"            body");
             sb.AppendLine($"          end");
             sb.AppendLine($"        end,");
             sb.AppendLine($"        output_fields: lambda do |object_definitions|");

--- a/tools/SdkGenerator/SdkGenerator/SdkGenerator.csproj
+++ b/tools/SdkGenerator/SdkGenerator/SdkGenerator.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
+        <PackAsTool>true</PackAsTool>
+        <ToolCommandName>SdkGenerator</ToolCommandName>
     </PropertyGroup>
 
     <ItemGroup>
@@ -17,32 +19,31 @@
 
     <ItemGroup>
         <None Update="Templates\csharp\ApiClient.cs.scriban">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </None>
-        <None Update="Templates\ruby\ApiClient.rb.scriban">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </None>
-        <None Update="Templates\java\ApiClient.java.scriban">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </None>
-        <None Update="Templates\ts\ApiClient.ts.scriban">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </None>
-        <None Update="Templates\python\ApiClient.py.scriban">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
         <None Update="Templates\csharp\sdk.nuspec.scriban">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </None>
-        <None Remove="Templates\ts\package.json.scriban" />
-        <None Update="Templates\python\__init__.py.scriban">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </None>
-        <None Update="Templates\ts\index.ts.scriban">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
         <None Update="Templates\csharp\ApiInterface.cs.scriban">
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="Templates\java\ApiClient.java.scriban">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="Templates\python\ApiClient.py.scriban">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="Templates\python\__init__.py.scriban">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="Templates\ruby\ApiClient.rb.scriban">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="Templates\ts\ApiClient.ts.scriban">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="Templates\ts\index.ts.scriban">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
New API call methods look like this:

```
      query_projects: {
        title: "Query Projects",
        subtitle: "Retrieve a list of Projects that match an [OData formatted query](https://www.odata.org/).",
        display_priority: "4",
        input_fields: lambda do |object_definitions|
          { name: "$top", label: "$top", control_type: "integer", type: :number },
          { name: "$skip", label: "$skip", control_type: "integer", type: :number },
          { name: "$filter", label: "$filter", control_type: "text", type: :string },
          { name: "$select", label: "$select", control_type: "text", type: :string },
          { name: "$orderby", label: "$orderby", control_type: "text", type: :string },
          { name: "$expand", label: "$expand", control_type: "text", type: :string },
        end,
        execute: lambda do |connection, input|
          queryString = {
            $top: input["$top"],
            $skip: input["$skip"],
            $filter: input["$filter"],
            $select: input["$select"],
            $orderby: input["$orderby"],
            $expand: input["$expand"],
          }.to_query
          result = get("/project-api/public/projects?#{queryString}").after_response do |code, body, headers|
            body
          end
        end,
        output_fields: lambda do |object_definitions|
          object_definitions['project_dto_list_astro_result']
        end,
      },
```