### PR TITLE
Fix build command

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -26,15 +26,9 @@ jobs:
       - name: Build solution and generate NuGet package
         run: dotnet build -c Release
 
-      - name: Setup Nuget
-        uses: nuget/setup-nuget@v1
-        with:
-          nuget-api-key: ${{ secrets.NUGET_API_KEY }}
-          nuget-version: "5.x"
-
       - name: Run Nuget pack
-        run: nuget pack SdkGenerator.nuspec
+        run: dotnet pack --configuration Release /p:NuspecFile=../../SdkGenerator.nuspec
 
       - name: Push generated package to NuGet registry
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
+        run: dotnet nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}

--- a/PatchNotes.md
+++ b/PatchNotes.md
@@ -1,3 +1,8 @@
+# 1.1.2
+August 21, 2023
+
+* Fixed tool deployment
+
 # 1.1.1
 August 18, 2023
 

--- a/SdkGenerator.nuspec
+++ b/SdkGenerator.nuspec
@@ -2,7 +2,7 @@
 <package >
     <metadata>
         <id>SdkGenerator</id>
-        <version>1.1.1</version>
+        <version>1.1.2-beta</version>
         <title>SdkGenerator</title>
         <authors>Ted Spence</authors>
         <owners>Ted Spence</owners>
@@ -18,14 +18,10 @@
         <summary>Command line dotnet tool to generate SDKs for your Swagger/OpenAPI project.</summary>
         <icon>docs/icons-puzzle.png</icon>
         <releaseNotes>
-            # 1.1.1
-            August 18, 2023
+            # 1.1.2-beta
+            August 21, 2023
 
-            * Improvements to reliability for endpoints that lack documentation.
-            * Fixed issues with handling of string enums.
-            * Convert all enums to constants and add reference documentation.
-            * Generate the github workflow YML file for publishing.
-            * Remove fixed ErrorResult.cs file.
+            * Fixed tool deployment
         </releaseNotes>
         <copyright>Copyright 2021 - 2023</copyright>
         <tags>SDK generator swagger openapi swashbuckle</tags>

--- a/src/SdkGenerator/Program.cs
+++ b/src/SdkGenerator/Program.cs
@@ -17,7 +17,7 @@ public static class Program
 {
     private class BaseOptions
     {
-        [Option('p', "project", HelpText = "Specify a project file")]
+        [Option('p', "project", Required = true, HelpText = "Specify a project file")]
         public string ProjectFile { get; set; }
         
         [Option('l', "log", HelpText = "Write errors to a log file on disk. If null, writes to stdout")]

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net7.0</TargetFramework>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>SdkGenerator</ToolCommandName>
+        <PackageOutputPath>../../</PackageOutputPath>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Found two problems:
* If you install the tool with `dotnet tool install --global SdkGenerator` it fails.  Let's try following some more instructions and switching away from using the NuGet command line tool towards the DotNet tool.
* If you run the program as `SdkGenerator build` it crashes rather than telling you what command you forgot.  Let's fix that.