### PR TITLE
Fix issues found during local debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Examples of assumptions about OpenAPI made by this program:
 * You have a list of public environments (e.g. production, sandbox) that are documented in the SDK
 * For test environments or dedicated servers, an SDK user must define a custom environment URL
 * [Enums are sometimes unsafe for SDK usage](https://medium.com/codex/should-your-api-use-enums-340a6b51d6c3); all enums are converted to integers or strings
-* Nobody intentionally adds HttpStatusCode to their swagger file; if it appears, ignore it.
-
+* Nobody intentionally adds HttpStatusCode to their swagger file; if it appears, ignore it
+* Each API has a unique `summary` value in the swagger file which will be used as method names for the SDK
 
 ## Attribution
 

--- a/src/SdkGenerator/Diff/PatchNotesGenerator.cs
+++ b/src/SdkGenerator/Diff/PatchNotesGenerator.cs
@@ -53,7 +53,7 @@ public class PatchNotesGenerator
                 var changes = GetSchemaChanges(item, prevItem);
                 if (changes.Any())
                 {
-                    diff.SchemaChanges.Add(item.Name, changes);
+                    diff.SchemaChanges[item.Name] = changes;
                 }
             }
 
@@ -91,14 +91,14 @@ public class PatchNotesGenerator
             dict.TryGetValue(name, out var prevItem);
             if (prevItem == null)
             {
-                diff.NewEndpoints.Add(name, item);
+                diff.NewEndpoints[name] = item;
             }
             else
             {
                 var changes = GetEndpointChanges(item, prevItem);
                 if (changes.Any())
                 {
-                    diff.EndpointChanges.Add(name, changes);
+                    diff.EndpointChanges[name] = changes;
                 }
             }
 

--- a/src/SdkGenerator/Diff/PatchNotesGenerator.cs
+++ b/src/SdkGenerator/Diff/PatchNotesGenerator.cs
@@ -91,6 +91,10 @@ public class PatchNotesGenerator
             dict.TryGetValue(name, out var prevItem);
             if (prevItem == null)
             {
+                if (diff.NewEndpoints.ContainsKey(name))
+                {
+                    current.LogError($"Duplicate API name: {name}");
+                }
                 diff.NewEndpoints[name] = item;
             }
             else

--- a/src/SdkGenerator/PatchNotes.md
+++ b/src/SdkGenerator/PatchNotes.md
@@ -1,3 +1,8 @@
+# 1.1.8
+September 14, 2023
+
+* Minor fixes for local debugging and duplicate API names
+
 # 1.1.7
 September 10, 2023
 

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -12,15 +12,14 @@
     <PackageTags>SDK generator swagger openapi swashbuckle</PackageTags>
     <Copyright>Copyright 2021 - 2023</Copyright>
     <PackageReleaseNotes>
-      # 1.1.7
-      September 10, 2023
+      # 1.1.8
+      September 14, 2023
 
-      * Updated build process to modern DotNet standards, with thanks to [Chet Husk](https://github.com/baronfel)
-      * We no longer need a DotNetToolSettings.xml file nor a NuSpec file
+      * Minor fixes for local debugging and duplicate API names
     </PackageReleaseNotes>
     <PackageIcon>docs/icons-puzzle.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.1.7</Version>
+    <Version>1.1.8</Version>
     <Authors>Ted Spence</Authors>
     <!-- Project Url is filled in by sourcelink in the .NET 8 SDK, but you can add it explicitly via
     package -->

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -71,7 +71,7 @@
     <None
         Include="Templates/**/*"
         Pack="true"
-        CopyToPublishDirectory="PreserveNewest" />
+        CopyToPublishDirectory="PreserveNewest" CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Looks like the build changes caused a problem for local debugging - let's fix.

While doing this, we will add detection for duplicative API names.