### PR TITLE
Fix Java SDK builder crash

### DIFF
--- a/src/SdkGenerator/Languages/JavaSdk.cs
+++ b/src/SdkGenerator/Languages/JavaSdk.cs
@@ -421,7 +421,7 @@ public class JavaSdk : ILanguageSdk
         // Let's try using Scriban to populate these files
         await ScribanFunctions.ExecuteTemplateIfNotExists(context, 
             "SdkGenerator.Templates.java.publish.yml.scriban",
-            context.MakePath(context.Project.Csharp.Folder, ".github", "workflows", "publish.yml"));
+            context.MakePath(context.Project.Java.Folder, ".github", "workflows", "publish.yml"));
         await ScribanFunctions.ExecuteTemplate(context, 
             "SdkGenerator.Templates.java.ApiClient.java.scriban",
             context.MakePath(context.Project.Java.Folder, "src", "main", "java",

--- a/src/SdkGenerator/PatchNotes.md
+++ b/src/SdkGenerator/PatchNotes.md
@@ -1,3 +1,8 @@
+# 1.3.6
+October 18, 2024
+
+* Fixed a minor typo that caused Java-only SDK builds to fail
+
 # 1.3.5
 October 4, 2024
 

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -12,17 +12,14 @@
     <PackageTags>SDK generator swagger openapi swashbuckle</PackageTags>
     <Copyright>Copyright 2021 - 2024</Copyright>
     <PackageReleaseNotes>
-      # 1.3.5
-      October 4, 2024
+      # 1.3.6
+      October 18, 2024
 
-      * Improvements to Java pom.xml format to deploy via SonaType Central
-      * Python package names are properly sorted
-      * Python array results are properly parsed, even if they have extra fields
-      * Nested references no longer generate incorrect imports in Python
+      * Fixed a minor typo that caused Java-only SDK builds to fail
     </PackageReleaseNotes>
     <PackageIcon>docs/icons-puzzle.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.3.5</Version>
+    <Version>1.3.6</Version>
     <Authors>Ted Spence</Authors>
     <!-- Project Url is filled in by sourcelink in the .NET 8 SDK, but you can add it explicitly via
     package -->


### PR DESCRIPTION
Apparently I left a stray "CSharp" reference in the Java builder.  Yuck!

Easy enough to fix.