### PR TITLE
Fixes for python and typescript

### DIFF
--- a/src/SdkGenerator/Languages/PythonSdk.cs
+++ b/src/SdkGenerator/Languages/PythonSdk.cs
@@ -455,7 +455,7 @@ public class PythonSdk : ILanguageSdk
         // Let's try using Scriban to populate these files
         await ScribanFunctions.ExecuteTemplateIfNotExists(context, 
             "SdkGenerator.Templates.python.publish.yml.scriban",
-            context.MakePath(context.Project.Csharp.Folder, ".github", "workflows", "publish.yml"));
+            context.MakePath(context.Project.Python.Folder, ".github", "workflows", "publish.yml"));
         await ScribanFunctions.ExecuteTemplate(context, 
             "SdkGenerator.Templates.python.ApiClient.scriban",
             context.MakePath(context.Project.Python.Folder, "src", context.Project.Python.Namespace, context.Project.Python.ClassName.WordsToSnakeCase() + ".py"));

--- a/src/SdkGenerator/Languages/TypescriptSdk.cs
+++ b/src/SdkGenerator/Languages/TypescriptSdk.cs
@@ -367,7 +367,7 @@ public class TypescriptSdk : ILanguageSdk
         // Let's try using Scriban to populate these files
         await ScribanFunctions.ExecuteTemplateIfNotExists(context, 
             "SdkGenerator.Templates.ts.publish.yml.scriban",
-            context.MakePath(context.Project.Csharp.Folder, ".github", "workflows", "publish.yml"));
+            context.MakePath(context.Project.Typescript.Folder, ".github", "workflows", "publish.yml"));
         await ScribanFunctions.ExecuteTemplate(context, 
             "SdkGenerator.Templates.ts.ApiClient.scriban",
             context.MakePath(context.Project.Typescript.Folder, "src", context.Project.Typescript.ClassName + ".ts"));

--- a/src/SdkGenerator/PatchNotes.md
+++ b/src/SdkGenerator/PatchNotes.md
@@ -1,3 +1,8 @@
+# 1.3.7
+October 20, 2024
+
+* Fixed a minor typo that caused Typescript and Python-only build configs to fail
+
 # 1.3.6
 October 18, 2024
 

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -12,10 +12,10 @@
     <PackageTags>SDK generator swagger openapi swashbuckle</PackageTags>
     <Copyright>Copyright 2021 - 2024</Copyright>
     <PackageReleaseNotes>
-      # 1.3.6
-      October 18, 2024
+      # 1.3.7
+      October 20, 2024
 
-      * Fixed a minor typo that caused Java-only SDK builds to fail
+      * Fixed a minor typo that caused Typescript and Python-only build configs to fail
     </PackageReleaseNotes>
     <PackageIcon>docs/icons-puzzle.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Fix embarrassing typos that never caused a problem until we implemented single automated PR builds