### PR TITLE
By default, skip SDK generation if changes are trivial

### DIFF
--- a/src/SdkGenerator/Diff/SwaggerDiff.cs
+++ b/src/SdkGenerator/Diff/SwaggerDiff.cs
@@ -56,7 +56,18 @@ public class SwaggerDiff
     /// <summary>
     /// True if this change is trivial - e.g. no schemas or endpoints have changed
     /// </summary>
-    public bool IsMinorChange { get; set; }
+    public bool IsMinorChange {
+        get
+        {
+            return !(SchemaChanges.Any() 
+                   || EndpointChanges.Any()
+                   || DeprecatedEndpoints.Any() 
+                   || DeprecatedSchemas.Any() 
+                   || NewSchemas.Any() 
+                   || NewEndpoints.Any() 
+                   || Renames.Any());
+        }
+    }
 
     /// <summary>
     /// Convert this diff into a shortened summary of patch notes in Markdown format 

--- a/src/SdkGenerator/Diff/SwaggerDiff.cs
+++ b/src/SdkGenerator/Diff/SwaggerDiff.cs
@@ -52,6 +52,11 @@ public class SwaggerDiff
     /// For schemas that changed, a description of the changes
     /// </summary>
     public Dictionary<string, List<string>> SchemaChanges { get; set; } = new();
+    
+    /// <summary>
+    /// True if this change is trivial - e.g. no schemas or endpoints have changed
+    /// </summary>
+    public bool IsMinorChange { get; set; }
 
     /// <summary>
     /// Convert this diff into a shortened summary of patch notes in Markdown format 

--- a/src/SdkGenerator/Program.cs
+++ b/src/SdkGenerator/Program.cs
@@ -52,7 +52,7 @@ public static class Program
         public string SwaggerFile { get; set; }
         
         [Option(HelpText = "Skip generation if only minor changes are found")]
-        public bool? SkipMinorChanges { get; set; }
+        public bool SkipMinorChanges { get; set; }
     }
     
     [Verb("create", HelpText = "Create a new template file for a new SDK")]
@@ -263,9 +263,14 @@ public static class Program
 
         // Generate patch notes and detect if this is a meaningful change
         context.PatchNotes = await DownloadFile.GeneratePatchNotes(context);
+        Console.WriteLine($"Comparing with previous version {context.PatchNotes.OldVersion}...");
         if (options.SkipMinorChanges == true && context.PatchNotes.IsMinorChange)
         {
             Console.WriteLine("Skipping SDK generation since this is a minor change.");
+            if (context.SwaggerJsonPath != null && File.Exists(context.SwaggerJsonPath))
+            {
+                File.Delete(context.SwaggerJsonPath);
+            }
             return;
         }
         

--- a/src/SdkGenerator/Program.cs
+++ b/src/SdkGenerator/Program.cs
@@ -51,8 +51,8 @@ public static class Program
         [Option('f', "file", HelpText = "Use a specific OpenAPI/Swagger file and do not attempt to download from source")]
         public string SwaggerFile { get; set; }
         
-        [Option(HelpText = "Skip generation if only minor changes are found")]
-        public bool SkipMinorChanges { get; set; }
+        [Option(HelpText = "Still generate SDK even if changes are minor")]
+        public bool GenerateIfMinor { get; set; }
     }
     
     [Verb("create", HelpText = "Create a new template file for a new SDK")]
@@ -264,7 +264,7 @@ public static class Program
         // Generate patch notes and detect if this is a meaningful change
         context.PatchNotes = await DownloadFile.GeneratePatchNotes(context);
         Console.WriteLine($"Comparing with previous version {context.PatchNotes.OldVersion}...");
-        if (options.SkipMinorChanges == true && context.PatchNotes.IsMinorChange)
+        if (options.GenerateIfMinor != true && context.PatchNotes.IsMinorChange)
         {
             Console.WriteLine("Skipping SDK generation since this is a minor change.");
             if (context.SwaggerJsonPath != null && File.Exists(context.SwaggerJsonPath))

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -12,14 +12,15 @@
     <PackageTags>SDK generator swagger openapi swashbuckle</PackageTags>
     <Copyright>Copyright 2021 - 2024</Copyright>
     <PackageReleaseNotes>
-      # 1.3.8
-      October 20, 2024
+      # 1.3.9
+      December 9, 2024
 
-      * Fixed an issue with ignored parameters
+      * Option to avoid generation if no significant OpenAPI changes are detected
+      * Update System.Text.Json package version
     </PackageReleaseNotes>
     <PackageIcon>docs/icons-puzzle.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.3.8</Version>
+    <Version>1.3.9</Version>
     <Authors>Ted Spence</Authors>
     <!-- Project Url is filled in by sourcelink in the .NET 8 SDK, but you can add it explicitly via
     package -->

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -15,8 +15,8 @@
       # 1.3.9
       December 9, 2024
 
-      * Option to avoid generation if no significant OpenAPI changes are detected
-      * Update System.Text.Json package version
+      * By default, avoid SDK generation if no significant OpenAPI changes are detected
+      * Update System.Text.Json package version [DotNet]
     </PackageReleaseNotes>
     <PackageIcon>docs/icons-puzzle.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/SdkGenerator/Templates/csharp/sdk.nuspec.scriban
+++ b/src/SdkGenerator/Templates/csharp/sdk.nuspec.scriban
@@ -22,7 +22,7 @@
 		<dependencies>
 			<group targetFramework=".NETStandard2.0">
 				<dependency id="System.Net.Http" version="4.3.4" />
-				<dependency id="System.Text.Json" version="6.0.2" />
+				<dependency id="System.Text.Json" version="9.0.0" />
 			</group>
 		</dependencies>
 	</metadata>


### PR DESCRIPTION
I noticed I was getting lots of unnecessary pull requests on my SDK repositories with trivial changes.

Let's make the program skip generation unless there are meaningful changes to the OpenAPI file.