### PR TITLE
Downgrade to DotNet 8

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET Core @ Latest
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "9.0.x"
+          dotnet-version: "8.0.x"
           include-prerelease: false
 
       - name: Build solution and generate NuGet package

--- a/src/SdkGenerator/PatchNotes.md
+++ b/src/SdkGenerator/PatchNotes.md
@@ -1,3 +1,8 @@
+# 1.3.11
+January 31, 2025
+
+* Downgraded to DotNet 8.0 for compatibility with existing GitHub actions workflows
+
 # 1.3.10
 January 14, 2025
 

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>SdkGenerator</ToolCommandName>
     <PackageReadmeFile>docs/README.md</PackageReadmeFile>
@@ -12,11 +12,10 @@
     <PackageTags>SDK generator swagger openapi swashbuckle</PackageTags>
     <Copyright>Copyright 2021 - 2024</Copyright>
     <PackageReleaseNotes>
-      # 1.3.10
-      January 14, 2025
+      # 1.3.11
+      January 31, 2025
 
-      * Removed copyright years from file templates to avoid unnecessary changes
-      * Upgraded to DotNet 9.0
+      * Downgraded to DotNet 8.0 for compatibility with existing GitHub actions workflows
     </PackageReleaseNotes>
     <PackageIcon>docs/icons-puzzle.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
In testing, a lot of GitHub actions now fail when the app is on DotNet 9.  Let's go back to 8.