### PR TITLE
TypeScript and C# patches

### DIFF
--- a/src/SdkGenerator/Templates/csharp/publish.yml.scriban
+++ b/src/SdkGenerator/Templates/csharp/publish.yml.scriban
@@ -20,22 +20,17 @@ jobs:
       - name: Setup .NET Core @ Latest
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: |
+            8.x
+            9.x
 
       - name: Build solution and generate NuGet package
         run: dotnet build -c Release
 
-      - name: Setup Nuget
+      - name: Run DotNet pack
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: nuget/setup-nuget@v2
-        with:
-          nuget-api-key: ${{ "{{ secrets.NUGET_API_KEY }}" }}
-          nuget-version: "5.x"
-
-      - name: Run Nuget pack
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: nuget pack {{ project.csharp.class_name }}.nuspec
+        run: dotnet pack
 
       - name: Push generated package to GitHub registry
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{ "{{ secrets.NUGET_API_KEY }}" }}
+        run: dotnet nuget push src/bin/Release/*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${{ secrets.NUGET_API_KEY }}

--- a/src/SdkGenerator/Templates/ts/package.json.scriban
+++ b/src/SdkGenerator/Templates/ts/package.json.scriban
@@ -30,16 +30,13 @@
     "main": "{{ project.typescript.module_name }}.js",
     "types": "{{ project.typescript.module_name }}.d.ts",
     "devDependencies": {
-        "@rollup/plugin-node-resolve": "^13.1.3",
-        "@rollup/plugin-typescript": "^8.3.0",
-        "@typescript-eslint/eslint-plugin": "^5.14.0",
-        "@typescript-eslint/parser": "^5.14.0",
+        "@types/node": "^20.8.4",
+        "@typescript-eslint/eslint-plugin": "^6.7.5",
+        "@typescript-eslint/parser": "^6.7.5",
+        "esbuild": "^0.25.0",
+        "esbuild-plugin-tsc": "^0.4.0",
         "eslint": "^8.11.0",
-        "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",
-        "rollup": "^2.67.0",
-        "rollup-plugin-dts": "^4.1.0",
-        "typescript": "^4.5.5",
-        "uglify-js": "^3.15.0"
+        "typescript": "^4.5.5"
     }
 }


### PR DESCRIPTION
From testing today:
* The CSharp code updates the nuspec file rather than the csproj file; the latest build system uses only the csproj file.
* The TypeScript code has npm audit issues with esbuild.

To fix, we'll need to update the way the C# code is generated so that it can create/modify the csproj file instead.