### PR TITLE
Improvements for Java and Python autodeploy

### DIFF
--- a/src/SdkGenerator/PatchNotes.md
+++ b/src/SdkGenerator/PatchNotes.md
@@ -1,3 +1,8 @@
+# 1.3.13
+June 9, 2025
+
+* Java: Added null coalescing for project/url to pom.xml; this is a SonaType requirement for publishing so it can't be null
+
 # 1.3.12
 April 21, 2025
 

--- a/src/SdkGenerator/PatchNotes.md
+++ b/src/SdkGenerator/PatchNotes.md
@@ -2,6 +2,7 @@
 June 9, 2025
 
 * Java: Added null coalescing for project/url to pom.xml; this is a SonaType requirement for publishing so it can't be null
+* Python: Stop using Pyre for type checking; it no longer works reliably on GitHub actions
 
 # 1.3.12
 April 21, 2025

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -12,14 +12,13 @@
     <PackageTags>SDK generator swagger openapi swashbuckle</PackageTags>
     <Copyright>Copyright 2021 - 2025</Copyright>
     <PackageReleaseNotes>
-      April 21, 2025
+      June 9, 2025
 
-      * DotNet: Fixed DotNet SDKs to use csproj files rather than nuspec
-      * DotNet: Added xmldoc for fileBytes parameters for file uploads
+      * Java: Added null coalescing for project/url to pom.xml; this is a SonaType requirement for publishing so it can't be null
     </PackageReleaseNotes>
     <PackageIcon>docs/icons-puzzle.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.3.12</Version>
+    <Version>1.3.13</Version>
     <Authors>Ted Spence</Authors>
     <!-- Project Url is filled in by sourcelink in the .NET 8 SDK, but you can add it explicitly via
     package -->

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -15,6 +15,7 @@
       June 9, 2025
 
       * Java: Added null coalescing for project/url to pom.xml; this is a SonaType requirement for publishing so it can't be null
+      * Python: Stop using Pyre for type checking; it no longer works reliably on GitHub actions
     </PackageReleaseNotes>
     <PackageIcon>docs/icons-puzzle.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/SdkGenerator/Templates/java/pom.xml.scriban
+++ b/src/SdkGenerator/Templates/java/pom.xml.scriban
@@ -8,7 +8,7 @@
 
     <name>{{ project.java.module_name }}</name>
     <description>{{ project.description }} for Java</description>
-    <url>{{ project.documentation_url }}</url>
+    <url>{{ project.documentation_url ?? project.java.github_url }}</url>
 
     <licenses>
         <license>
@@ -28,6 +28,7 @@
             <id>{{ project.java.namespace }}</id>
             <name>{{ project.author_name }}</name>
             <email>{{ project.author_email }}</email>
+            <url>{{ project.java.github_url }}</url>
         </developer>
     </developers>
 

--- a/src/SdkGenerator/Templates/python/publish.yml.scriban
+++ b/src/SdkGenerator/Templates/python/publish.yml.scriban
@@ -24,11 +24,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
-    - name: Run Pyre
-      run: |
-        python -m pip install pyre-check
-        python -m pip install dacite
-        pyre --source-directory src check
     - name: Build package
       run: python -m build
     - name: Publish package


### PR DESCRIPTION
In testing this month:
* SonaType rejects Java publish with "Project URL is not defined" if `/project/url` is blank
* Python tests on Pyre are failing for unclear reasons

Let's fix this by using null coalescing on the SonaType URL box, and by removing Pyre.  I'll try to investigate PyLance/PyRight next to see if it works better.