### PR TITLE
Improve patch notes generation

### DIFF
--- a/SdkGenerator.Tests/ContextBuilder.cs
+++ b/SdkGenerator.Tests/ContextBuilder.cs
@@ -78,4 +78,16 @@ public class ContextBuilder
         field!.DataType = newType;
         return this;
     }
+
+    public ContextBuilder AddApi(string path, HttpMethod method, string category, string name)
+    {
+        _api.Endpoints.Add(new EndpointItem()
+        {
+            Path = path,
+            Method = method.ToString().ToLower(),
+            Category = category,
+            Name = name,
+        });
+        return this;
+    }
 }

--- a/SdkGenerator.Tests/PatchNotesTests.cs
+++ b/SdkGenerator.Tests/PatchNotesTests.cs
@@ -130,6 +130,7 @@ public class PatchNotesTests
         Assert.AreEqual(0, diff.EndpointChanges.Count);
         Assert.AreEqual(0, diff.SchemaChanges.Count);
         Assert.AreEqual(1, diff.Renames.Count);
-        Assert.AreEqual("Renamed 'Test.DoSomethingMethod' to 'Test.DoSomething'", diff.Renames[0]);
+        Assert.AreEqual("Test.DoSomethingMethod", diff.Renames[0].OldName);
+        Assert.AreEqual("DoSomething", diff.Renames[0].Endpoint.Name);
     }
 }

--- a/SdkGenerator.Tests/PatchNotesTests.cs
+++ b/SdkGenerator.Tests/PatchNotesTests.cs
@@ -112,4 +112,24 @@ public class PatchNotesTests
         Assert.AreEqual("SchemaTypeOne", change.Key);
         Assert.AreEqual("SchemaTypeOne: Changed the data type of the field `id` from `Guid` to `String`", change.Value.FirstOrDefault());
     }
+    
+    
+    [TestMethod]
+    public void EndpointNameChange()
+    {
+        using var v1 = new ContextBuilder()
+            .AddApi("/test/api/do-something", HttpMethod.Post, "Test", "DoSomethingMethod") 
+            .Build();
+        using var v2 = new ContextBuilder()
+            .AddApi("/test/api/do-something", HttpMethod.Post, "Test", "DoSomething") 
+            .Build();
+        
+        var diff = PatchNotesGenerator.Compare(v1, v2);
+        Assert.AreEqual(0, diff.NewEndpoints.Count);
+        Assert.AreEqual(0, diff.DeprecatedEndpoints.Count);
+        Assert.AreEqual(0, diff.EndpointChanges.Count);
+        Assert.AreEqual(0, diff.SchemaChanges.Count);
+        Assert.AreEqual(1, diff.Renames.Count);
+        Assert.AreEqual("Renamed 'Test.DoSomethingMethod' to 'Test.DoSomething'", diff.Renames[0]);
+    }
 }

--- a/src/SdkGenerator/Diff/PatchNotesGenerator.cs
+++ b/src/SdkGenerator/Diff/PatchNotesGenerator.cs
@@ -145,12 +145,20 @@ public static class PatchNotesGenerator
             if (pathToName.TryGetValue(thisPathName, out var prevName))
             {
                 compared.Add(prevName);
+                
+                // If name changed, document that
                 if (name != prevName)
                 {
                     diff.Renames.Add($"Renamed '{prevName}' to '{name}'");
-                    if (nameToEndpoint.TryGetValue(prevName, out prevItem))
+                }
+                
+                // If endpoint had any meaningful changes, document those
+                if (nameToEndpoint.TryGetValue(prevName, out prevItem))
+                {
+                    var endpointChanges = GetEndpointChanges(current, item, prevItem);
+                    if (endpointChanges.Any())
                     {
-                        diff.EndpointChanges[name] = GetEndpointChanges(current, item, prevItem);
+                        diff.EndpointChanges[name] = endpointChanges;
                     }
                 }
             }

--- a/src/SdkGenerator/Diff/PatchNotesGenerator.cs
+++ b/src/SdkGenerator/Diff/PatchNotesGenerator.cs
@@ -149,7 +149,7 @@ public static class PatchNotesGenerator
                 // If name changed, document that
                 if (name != prevName)
                 {
-                    diff.Renames.Add($"Renamed '{prevName}' to '{name}'");
+                    diff.Renames.Add(new SwaggerRenameInfo() { Endpoint = item, OldName = prevName });
                 }
                 
                 // If endpoint had any meaningful changes, document those

--- a/src/SdkGenerator/Diff/PatchNotesGenerator.cs
+++ b/src/SdkGenerator/Diff/PatchNotesGenerator.cs
@@ -141,13 +141,17 @@ public static class PatchNotesGenerator
             var name = MakeApiName(item);
             
             // First check if the API was simply renamed
-            if (pathToName.TryGetValue(item.Path + ":" + item.Method, out var prevName) && name != prevName)
+            var thisPathName = item.Path + ":" + item.Method;
+            if (pathToName.TryGetValue(thisPathName, out var prevName))
             {
                 compared.Add(prevName);
-                diff.Renames.Add($"Renamed '{prevName}' to '{name}'");
-                if (nameToEndpoint.TryGetValue(prevName, out prevItem))
+                if (name != prevName)
                 {
-                    diff.EndpointChanges[name] = GetEndpointChanges(current, item, prevItem);
+                    diff.Renames.Add($"Renamed '{prevName}' to '{name}'");
+                    if (nameToEndpoint.TryGetValue(prevName, out prevItem))
+                    {
+                        diff.EndpointChanges[name] = GetEndpointChanges(current, item, prevItem);
+                    }
                 }
             }
             else

--- a/src/SdkGenerator/Diff/SwaggerDiff.cs
+++ b/src/SdkGenerator/Diff/SwaggerDiff.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using SdkGenerator.Project;
 using SdkGenerator.Schema;
 
 namespace SdkGenerator.Diff;
@@ -82,7 +83,7 @@ public class SwaggerDiff
         var newName = BuildVersionName(newVersionName, NewVersion);
         
         // Header for these patch notes
-        sb.AppendLine($"# Patch notes for {newName}");
+        sb.AppendLine($"## Patch notes for {newName}");
         sb.AppendLine();
         sb.AppendLine($"These patch notes summarize the changes from version {oldName}.");
         sb.AppendLine();

--- a/src/SdkGenerator/Diff/SwaggerDiff.cs
+++ b/src/SdkGenerator/Diff/SwaggerDiff.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using SdkGenerator.Project;
+using SdkGenerator.Links;
 using SdkGenerator.Schema;
 
 namespace SdkGenerator.Diff;
@@ -37,7 +37,7 @@ public class SwaggerDiff
     /// <summary>
     /// For endpoints that were renamed, a list of the renames
     /// </summary>
-    public List<string> Renames { get; set; } = new();
+    public List<SwaggerRenameInfo> Renames { get; set; } = new();
     
     /// <summary>
     /// New schema definitions
@@ -74,7 +74,7 @@ public class SwaggerDiff
     /// Convert this diff into a shortened summary of patch notes in Markdown format 
     /// </summary>
     /// <returns></returns>
-    public string ToSummaryMarkdown(string? oldVersionName, string? newVersionName)
+    public string ToSummaryMarkdown(string? oldVersionName, string? newVersionName, ILinkGenerator? linkGenerator)
     {
         var sb = new StringBuilder();
         
@@ -91,10 +91,18 @@ public class SwaggerDiff
         // Explain which APIs were added
         if (NewEndpoints.Count > 0)
         {
-            sb.AppendLine($"Added {NewEndpoints.Count} new APIs:");
+            sb.AppendLine($"Added {NewEndpoints.Count} new endpoints:");
             foreach (var api in NewEndpoints)
             {
-                sb.AppendLine($"* {api.Key} ({api.Value.Method.ToUpper()} {api.Value.Path})");
+                if (linkGenerator != null)
+                {
+                    var link = linkGenerator.MakeLink(api.Value);
+                    sb.AppendLine($"* [{api.Key}]({link})");
+                }
+                else
+                {
+                    sb.AppendLine($"* {api.Key}");
+                }
             }
             sb.AppendLine();
         }
@@ -102,10 +110,20 @@ public class SwaggerDiff
         // List name changes
         if (Renames.Count > 0)
         {
-            sb.AppendLine($"Renamed {Renames.Count} old APIs:");
+            sb.AppendLine($"Renamed {Renames.Count} endpoints:");
             foreach (var rename in Renames)
             {
-                sb.AppendLine($"* {rename}");
+                if (linkGenerator != null)
+                {
+                    var link = linkGenerator.MakeLink(rename.Endpoint);
+                    sb.AppendLine(
+                        $"* Renamed {rename.OldName} to [{rename.Endpoint.Category.ToProperCase()}.{rename.Endpoint.Name.ToProperCase()}]({link})");
+                }
+                else
+                {
+                    sb.AppendLine(
+                        $"* Renamed {rename.OldName} to {rename.Endpoint.Category.ToProperCase()}.{rename.Endpoint.Name.ToProperCase()}");
+                }
             }
 
             sb.AppendLine();
@@ -114,7 +132,7 @@ public class SwaggerDiff
         // APIs with changes
         if (EndpointChanges.Count > 0)
         {
-            sb.AppendLine($"Changes to existing APIs:");
+            sb.AppendLine($"Changes to existing endpoints:");
             foreach (var rename in EndpointChanges)
             {
                 foreach (var change in rename.Value)
@@ -144,7 +162,7 @@ public class SwaggerDiff
         // Explain which APIs were removed
         if (DeprecatedEndpoints.Count > 0)
         {
-            sb.AppendLine($"Deprecated {DeprecatedEndpoints.Count} old APIs:");
+            sb.AppendLine($"Deprecated {DeprecatedEndpoints.Count} old endpoints:");
             foreach (var api in DeprecatedEndpoints)
             {
                 sb.AppendLine($"* {api}");

--- a/src/SdkGenerator/Diff/SwaggerRenameInfo.cs
+++ b/src/SdkGenerator/Diff/SwaggerRenameInfo.cs
@@ -1,0 +1,10 @@
+﻿using SdkGenerator.Schema;
+
+namespace SdkGenerator.Diff;
+
+public class SwaggerRenameInfo
+{
+    public EndpointItem Endpoint { get; set; } = new();
+
+    public string OldName { get; set; } = string.Empty;
+}

--- a/src/SdkGenerator/Languages/CSharpSdk.cs
+++ b/src/SdkGenerator/Languages/CSharpSdk.cs
@@ -536,7 +536,7 @@ public class CSharpSdk : ILanguageSdk
             await ScribanFunctions.PatchXml(context, csprojFile.FullName, 8, "Authors", context.Project.AuthorName);
             await ScribanFunctions.PatchXml(context, csprojFile.FullName, 8, "Description", context.Project.Description + " for DotNet");
             await ScribanFunctions.PatchXml(context, csprojFile.FullName, 8, "Summary", context.Project.ProjectName + " for DotNet");
-            await ScribanFunctions.PatchXml(context, csprojFile.FullName, 8, "PackageReleaseNotes", context.PatchNotes.ToSummaryMarkdown(null, null));
+            await ScribanFunctions.PatchXml(context, csprojFile.FullName, 8, "PackageReleaseNotes", context.PatchNotes.ToSummaryMarkdown(null, null, null));
             await ScribanFunctions.PatchXml(context, csprojFile.FullName, 8, "Copyright", $"Copyright {context.Project.ProjectStartYear} - {DateTime.Now.Year}");
             await ScribanFunctions.PatchXml(context, csprojFile.FullName, 8, "PackageTags", context.Project.Keywords);
         }

--- a/src/SdkGenerator/Links/FernLinkGenerator.cs
+++ b/src/SdkGenerator/Links/FernLinkGenerator.cs
@@ -1,0 +1,13 @@
+﻿using SdkGenerator.Schema;
+
+namespace SdkGenerator.Links;
+
+public class FernLinkGenerator(string Host) : ILinkGenerator
+{
+    public string MakeLink(EndpointItem endpoint)
+    {
+        return
+            $"https://{Host}/api-reference/"
+            + $"{endpoint.Category.CamelCaseToSnakeCase().Replace('_', '-')}/{endpoint.Name.CamelCaseToSnakeCase().Replace('_', '-')}";
+    }
+}

--- a/src/SdkGenerator/Links/ILinkGenerator.cs
+++ b/src/SdkGenerator/Links/ILinkGenerator.cs
@@ -1,0 +1,8 @@
+﻿using SdkGenerator.Schema;
+
+namespace SdkGenerator.Links;
+
+public interface ILinkGenerator
+{
+    public string MakeLink(EndpointItem endpoint);
+}

--- a/src/SdkGenerator/PatchNotes.md
+++ b/src/SdkGenerator/PatchNotes.md
@@ -1,3 +1,9 @@
+# 1.3.17
+November 11, 2025
+
+* Better patch notes generation - includes option to add markdown links
+* Date categorization inside patch notes
+
 # 1.3.16
 October 19, 2025
 

--- a/src/SdkGenerator/Program.cs
+++ b/src/SdkGenerator/Program.cs
@@ -77,6 +77,10 @@ public static class Program
         
         [Option('p', "patch-notes", Required = true, HelpText = "The file name for the comprehensive patch notes file")]
         public string? PatchNotesFile { get; set; }
+        
+        [Option('d', "dates-file", Required = true, HelpText = "A JSON file containing dates for each swagger version")]
+        public string? DatesFile { get; set; }
+
     }
 
     [Verb("get-patch-notes", HelpText = "Get patch notes in Markdown for the current build")]
@@ -143,6 +147,9 @@ public static class Program
         {
             return;
         }
+        
+        // Capture dates for patch notes files
+        var dates = await rootContext.GetSwaggerDates();
         
         // List all files in the swagger folder
         var allSwaggerFiles = Directory.GetFiles(rootContext.MakePath(rootContext.Project.SwaggerSchemaFolder)).ToList();
@@ -229,15 +236,44 @@ public static class Program
         }
         Console.WriteLine($"Loaded {versions.Count} swagger files. Generating patch notes...");
         
-        // Sort them based on their version numbers
+        // Sort them based on their version numbers and apply dates
+        var dates = await SwaggerDates.FromDatesFile(arg.DatesFile);
         versions.Sort(new ContextSorter());
         var sb = new StringBuilder();
+        var currentDate = DateTime.UtcNow;
+        var currentYear = DateTime.UtcNow.Year;
+        DateOnly? lastPrintedDate = null;
         for (int i = 1; i < versions.Count; i++)
         {
+            var date = dates.GetDateForVersion(versions[i].OfficialVersion);
             var diffs = PatchNotesGenerator.Compare(versions[i - 1],versions[i]);
+
+            // Insert the month marker every time it changes
+            string dateHeader = string.Empty;
+            if (lastPrintedDate != null && lastPrintedDate.Value.Year == date.Year &&
+                lastPrintedDate.Value.Month == date.Month)
+            {
+                // nothing to print
+            }
+            else
+            {
+                if (currentYear != date.Year)
+                {
+                    dateHeader = $"# Updates from {date.Year}" + Environment.NewLine + Environment.NewLine;
+                }
+                else if (lastPrintedDate == null || date.Month != lastPrintedDate.Value.Month)
+                {
+                    dateHeader = $"# {date.ToString("MMMM, yyyy")}" + Environment.NewLine + Environment.NewLine;
+
+                }
+
+                // Month header
+                lastPrintedDate = date;
+            }
             
             // Stack them vertically, most recent first
-            sb.Insert(0, diffs.ToSummaryMarkdown(null, null) + Environment.NewLine + Environment.NewLine);
+            sb.Insert(0,
+                dateHeader + diffs.ToSummaryMarkdown(null, null) + Environment.NewLine + Environment.NewLine);
         }
         
         // Save to a comprehensive patch file
@@ -251,6 +287,9 @@ public static class Program
             // Or just emit to console
             Console.WriteLine(sb.ToString());
         }
+
+        // Keep track of dates
+        await dates.SaveDatesFile(arg.DatesFile);
     }
 
     private static async Task DiffTask(DiffOptions options)
@@ -282,6 +321,7 @@ public static class Program
         var diffs = PatchNotesGenerator.Compare(oldContext, newContext);
         
         // Print out human readable description
+        var dates = await newContext.GetSwaggerDates();
         Console.WriteLine(diffs.ToSummaryMarkdown(null, null));
     }
 
@@ -321,6 +361,7 @@ public static class Program
             var diffs = PatchNotesGenerator.Compare(oldContext, newContext);
 
             // Print out human readable description
+            var dates = await newContext.GetSwaggerDates();
             var diffMarkdown = diffs.ToSummaryMarkdown(options.OldFile, options.NewFile);
             
             // Do they also want us to send it to Slack? 
@@ -464,6 +505,7 @@ public static class Program
                 {
                     Folder = context.MakePath(context.Project.SwaggerSchemaFolder),
                     PatchNotesFile = context.MakePath(context.Project.PatchNotes.OutputFile),
+                    DatesFile = context.MakePath(context.Project.PatchNotes?.DatesFile),
                 };
                 await CompletePatchNotesTask(newOpt);
             }

--- a/src/SdkGenerator/Program.cs
+++ b/src/SdkGenerator/Program.cs
@@ -247,12 +247,16 @@ public static class Program
         }
         Console.WriteLine($"Loaded {versions.Count} swagger files. Generating patch notes...");
         
-        // Sort them based on their version numbers and apply dates
+        // Add page header and setup version feed
         var dates = await SwaggerDates.FromDatesFile(arg.DatesFile);
         versions.Sort(new ContextSorter());
         var sb = new StringBuilder();
+        sb.AppendLine("# API Patch Notes");
+        sb.AppendLine();
         var currentYear = DateTime.UtcNow.Year;
         DateOnly? lastPrintedDate = null;
+        
+        // Sort them based on their version numbers and apply dates
         for (int i = versions.Count - 1; i >= 1; i--)
         {
             var date = dates.GetDateForVersion(versions[i].OfficialVersion);
@@ -518,6 +522,8 @@ public static class Program
                     Folder = context.MakePath(context.Project.SwaggerSchemaFolder),
                     PatchNotesFile = context.MakePath(context.Project.PatchNotes.OutputFile),
                     DatesFile = context.MakePath(context.Project.PatchNotes?.DatesFile),
+                    Host = context.Project.PatchNotes?.Host,
+                    LinkFormat = context.Project.PatchNotes?.LinkFormat,
                 };
                 await CompletePatchNotesTask(newOpt);
             }

--- a/src/SdkGenerator/Program.cs
+++ b/src/SdkGenerator/Program.cs
@@ -9,6 +9,7 @@ using CommandLine;
 using Newtonsoft.Json;
 using SdkGenerator.Diff;
 using SdkGenerator.Languages;
+using SdkGenerator.Links;
 using SdkGenerator.Markdown;
 using SdkGenerator.Project;
 using SdkGenerator.Slack;
@@ -80,7 +81,12 @@ public static class Program
         
         [Option('d', "dates-file", Required = true, HelpText = "A JSON file containing dates for each swagger version")]
         public string? DatesFile { get; set; }
-
+        
+        [Option('h', "host", Required = false, HelpText = "The host name of the site where documentation is hosted")]
+        public string? Host { get; set; }
+        
+        [Option('l', "link-format", Required = false, HelpText = "The format of links to use ('None', 'Fern')")]
+        public string? LinkFormat { get; set; }
     }
 
     [Verb("get-patch-notes", HelpText = "Get patch notes in Markdown for the current build")]
@@ -175,7 +181,7 @@ public static class Program
             return;
         }
         var patchNotes = PatchNotesGenerator.Compare(prevContext, currentContext);
-        Console.WriteLine(patchNotes.ToSummaryMarkdown(null, null));
+        Console.WriteLine(patchNotes.ToSummaryMarkdown(null, null, null));
     }
 
     private static Task ListEmbeddedResourcesTask(ListEmbeddedResourcesOptions arg)
@@ -203,6 +209,11 @@ public static class Program
         {
             return;
         }
+        
+        // Make the link generator
+        ILinkGenerator? linkGenerator = string.Equals(arg.LinkFormat, "fern", StringComparison.CurrentCultureIgnoreCase)
+            ? new FernLinkGenerator(arg.Host ?? string.Empty)
+            : null;
         
         // Collect all swagger files from the folder
         var versions = new List<GeneratorContext>();
@@ -240,10 +251,9 @@ public static class Program
         var dates = await SwaggerDates.FromDatesFile(arg.DatesFile);
         versions.Sort(new ContextSorter());
         var sb = new StringBuilder();
-        var currentDate = DateTime.UtcNow;
         var currentYear = DateTime.UtcNow.Year;
         DateOnly? lastPrintedDate = null;
-        for (int i = 1; i < versions.Count; i++)
+        for (int i = versions.Count - 1; i >= 1; i--)
         {
             var date = dates.GetDateForVersion(versions[i].OfficialVersion);
             var diffs = PatchNotesGenerator.Compare(versions[i - 1],versions[i]);
@@ -257,14 +267,17 @@ public static class Program
             }
             else
             {
-                if (currentYear != date.Year)
+                if (currentYear - 1 == date.Year)
                 {
                     dateHeader = $"# Updates from {date.Year}" + Environment.NewLine + Environment.NewLine;
                 }
-                else if (lastPrintedDate == null || date.Month != lastPrintedDate.Value.Month)
+                else if (currentYear - 2 > date.Year)
+                {
+                    dateHeader = $"# Older patches" + Environment.NewLine + Environment.NewLine;
+                }
+                else if (lastPrintedDate == null || (date.Year == currentYear && date.Month != lastPrintedDate.Value.Month))
                 {
                     dateHeader = $"# {date.ToString("MMMM, yyyy")}" + Environment.NewLine + Environment.NewLine;
-
                 }
 
                 // Month header
@@ -272,8 +285,7 @@ public static class Program
             }
             
             // Stack them vertically, most recent first
-            sb.Insert(0,
-                dateHeader + diffs.ToSummaryMarkdown(null, null) + Environment.NewLine + Environment.NewLine);
+            sb.Append(dateHeader + diffs.ToSummaryMarkdown(null, null, linkGenerator) + Environment.NewLine + Environment.NewLine);
         }
         
         // Save to a comprehensive patch file
@@ -322,7 +334,7 @@ public static class Program
         
         // Print out human readable description
         var dates = await newContext.GetSwaggerDates();
-        Console.WriteLine(diffs.ToSummaryMarkdown(null, null));
+        Console.WriteLine(diffs.ToSummaryMarkdown(null, null, null));
     }
 
     private static async Task CompareTask(CompareOptions options)
@@ -362,7 +374,7 @@ public static class Program
 
             // Print out human readable description
             var dates = await newContext.GetSwaggerDates();
-            var diffMarkdown = diffs.ToSummaryMarkdown(options.OldFile, options.NewFile);
+            var diffMarkdown = diffs.ToSummaryMarkdown(options.OldFile, options.NewFile, null);
             
             // Do they also want us to send it to Slack? 
             if (!string.IsNullOrWhiteSpace(options.SlackEndpoint))

--- a/src/SdkGenerator/Project/GeneratorContext.cs
+++ b/src/SdkGenerator/Project/GeneratorContext.cs
@@ -213,4 +213,9 @@ public class GeneratorContext : IDisposable
     {
         return Project.IgnoredCategories != null && Project.IgnoredCategories.Contains(cat, StringComparer.OrdinalIgnoreCase);
     }
+    
+    public async Task<SwaggerDates> GetSwaggerDates()
+    {
+        return await SwaggerDates.FromDatesFile(Project.PatchNotes?.DatesFile); 
+    }
 }

--- a/src/SdkGenerator/Project/ProjectSchema.cs
+++ b/src/SdkGenerator/Project/ProjectSchema.cs
@@ -133,6 +133,8 @@ public class PatchNotesSchema
 {
     public string? OutputFile { get; set; }
     public string? DatesFile { get; set; }
+    public string? Host { get; set; }
+    public string? LinkFormat { get; set; }
 }
 
 public class CopySwaggerSchema

--- a/src/SdkGenerator/Project/ProjectSchema.cs
+++ b/src/SdkGenerator/Project/ProjectSchema.cs
@@ -132,6 +132,7 @@ public class WorkatoSchema
 public class PatchNotesSchema
 {
     public string? OutputFile { get; set; }
+    public string? DatesFile { get; set; }
 }
 
 public class CopySwaggerSchema

--- a/src/SdkGenerator/Project/SwaggerDates.cs
+++ b/src/SdkGenerator/Project/SwaggerDates.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace SdkGenerator.Project;
+
+public class SwaggerDate
+{
+    public string Version { get; set; } = string.Empty;
+    public DateOnly Date { get; set; }
+}
+
+/// <summary>
+/// This tragic object is necessary because swagger files do not contain "dates when this was updated"
+/// </summary>
+public class SwaggerDates
+{
+    public List<SwaggerDate> Dates { get; set; } = new();
+
+    public DateOnly GetDateForVersion(string version)
+    {
+        var date = Dates.Where(d => d.Version == version).FirstOrDefault();
+        if (date == null)
+        {
+            date = new SwaggerDate()
+            {
+                Version = version,
+                Date = DateOnly.FromDateTime(DateTime.UtcNow)
+            };
+            Dates.Add(date);
+        }
+        return date.Date;
+    }
+    
+    public static async Task<SwaggerDates> FromDatesFile(string? datesFile)
+    {
+        var dates = new SwaggerDates();
+        if (datesFile != null)
+        {
+            if (File.Exists(datesFile))
+            {
+                var text = await File.ReadAllTextAsync(datesFile);
+                dates = JsonConvert.DeserializeObject<SwaggerDates>(text) ?? new();
+            }
+        }
+
+        return dates;
+    }
+
+    public async Task SaveDatesFile(string? datesFile)
+    {
+        if (datesFile != null)
+        {
+            var text = JsonConvert.SerializeObject(this, Formatting.Indented);
+            await File.WriteAllTextAsync(datesFile, text);
+        }
+    }
+}

--- a/src/SdkGenerator/ScribanFunctions.cs
+++ b/src/SdkGenerator/ScribanFunctions.cs
@@ -117,7 +117,7 @@ public static class ScribanFunctions
         templateContext.PushGlobal(scriptObject1);
         templateContext.SetValue(new ScriptVariableGlobal("api"), context.Api);
         templateContext.SetValue(new ScriptVariableGlobal("project"), context.Project);
-        templateContext.SetValue(new ScriptVariableGlobal("patch_notes"), context.PatchNotes.ToSummaryMarkdown(null, null));
+        templateContext.SetValue(new ScriptVariableGlobal("patch_notes"), context.PatchNotes.ToSummaryMarkdown(null, null, null));
         
         // Add in some extra things if requested
         if (extraInfo != null)

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -12,17 +12,14 @@
     <PackageTags>SDK generator swagger openapi swashbuckle</PackageTags>
     <Copyright>Copyright 2021 - 2025</Copyright>
     <PackageReleaseNotes>
-        October 19, 2025
+        November 11, 2025
 
-        * Workato SDK improvements
-        * Converted project to nullability for type checking
-        * New build module in Project schema to generate complete patch notes ("PatchNotes")
-        * New build module in Project schema to copy current swagger file to designated location ("CopySwagger")
-        * Ability to compare against two distinct URLs to diff a test/staging site against production
+        * Better patch notes generation - includes option to add markdown links
+        * Date categorization inside patch notes
     </PackageReleaseNotes>
     <PackageIcon>docs/icons-puzzle.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.3.16</Version>
+    <Version>1.3.17</Version>
     <Authors>Ted Spence</Authors>
     <!-- Project Url is filled in by sourcelink in the .NET 8 SDK, but you can add it explicitly via
     package -->


### PR DESCRIPTION
I'd like to get better patch notes.  Let's do a few things:

* Add some tests to verify that renamed APIs are captured correctly
* Add support for dates to patch notes
