### PR TITLE
Detect path parameter renaming

### DIFF
--- a/SdkGenerator.Tests/PatchNotesTests.cs
+++ b/SdkGenerator.Tests/PatchNotesTests.cs
@@ -133,4 +133,34 @@ public class PatchNotesTests
         Assert.AreEqual("Test.DoSomethingMethod", diff.Renames[0].OldName);
         Assert.AreEqual("DoSomething", diff.Renames[0].Endpoint.Name);
     }
+
+    [TestMethod]
+    public void TestPathParameterExtraction()
+    {
+        var xyz = PatchNotesGenerator.GetPathParameterList("/api/{one}/test/{two}");
+        Assert.AreEqual(2, xyz.Count);
+        Assert.AreEqual("one", xyz[0]);
+        Assert.AreEqual("two", xyz[1]);
+    }
+    
+    [TestMethod]
+    public void PathParameterNameChange()
+    {
+        using var v1 = new ContextBuilder()
+            .AddApi("/test/api/{myId}/do-something", HttpMethod.Post, "Test", "DoSomethingMethod") 
+            .Build();
+        using var v2 = new ContextBuilder()
+            .AddApi("/test/api/{newId}/do-something", HttpMethod.Post, "Test", "DoSomethingMethod") 
+            .Build();
+        
+        var diff = PatchNotesGenerator.Compare(v1, v2);
+        Assert.AreEqual(0, diff.NewEndpoints.Count);
+        Assert.AreEqual(0, diff.DeprecatedEndpoints.Count);
+        Assert.AreEqual(1, diff.EndpointChanges.Count);
+        Assert.AreEqual(0, diff.SchemaChanges.Count);
+        Assert.AreEqual(0, diff.Renames.Count);
+        var change = diff.EndpointChanges.FirstOrDefault();
+        Assert.AreEqual("Test.DoSomethingMethod", change.Key);
+        Assert.AreEqual("Test.DoSomethingMethod changed the parameter name 'myId' to 'newId'", change.Value.FirstOrDefault());
+    }
 }

--- a/SdkGenerator.Tests/PatchNotesTests.cs
+++ b/SdkGenerator.Tests/PatchNotesTests.cs
@@ -137,10 +137,13 @@ public class PatchNotesTests
     [TestMethod]
     public void TestPathParameterExtraction()
     {
-        var xyz = PatchNotesGenerator.GetPathParameterList("/api/{one}/test/{two}");
-        Assert.AreEqual(2, xyz.Count);
-        Assert.AreEqual("one", xyz[0]);
-        Assert.AreEqual("two", xyz[1]);
+        var elements = "/api/{one}/test/{two}/action".PathBreakdown();
+        Assert.AreEqual(5, elements.Count);
+        Assert.AreEqual("/api/", elements[0]);
+        Assert.AreEqual("{one}", elements[1]);
+        Assert.AreEqual("/test/", elements[2]);
+        Assert.AreEqual("{two}", elements[3]);
+        Assert.AreEqual("/action", elements[4]);
     }
     
     [TestMethod]
@@ -161,6 +164,6 @@ public class PatchNotesTests
         Assert.AreEqual(0, diff.Renames.Count);
         var change = diff.EndpointChanges.FirstOrDefault();
         Assert.AreEqual("Test.DoSomethingMethod", change.Key);
-        Assert.AreEqual("Test.DoSomethingMethod changed the parameter name 'myId' to 'newId'", change.Value.FirstOrDefault());
+        Assert.AreEqual("Test.DoSomethingMethod changed the parameter name `{myId}` to `{newId}`", change.Value.FirstOrDefault());
     }
 }

--- a/src/SdkGenerator/Diff/PatchNotesGenerator.cs
+++ b/src/SdkGenerator/Diff/PatchNotesGenerator.cs
@@ -209,11 +209,24 @@ public static class PatchNotesGenerator
 
     private static List<string> GetEndpointChanges(GeneratorContext context, EndpointItem item, EndpointItem prevItem)
     {
+        var differences = new List<string>();
+        
         // Detect parameter renames
-        var oldParameters = GetPathParameterList(prevItem.Path);
-        if (!item.Path.Equals(prevItem.Path, StringComparison.OrdinalIgnoreCase))
+        var oldPathBreakdown = prevItem.Path.PathBreakdown();
+        var newPathBreakdown = item.Path.PathBreakdown();
+        if (oldPathBreakdown.Count != newPathBreakdown.Count)
         {
-            
+            differences.Add($"Breaking change: {MakeApiName(item)} path changed from `{prevItem.Path}` to `{item.Path}`");
+        }
+        else
+        {
+            for (int i = 0; i < oldPathBreakdown.Count; i++)
+            {
+                if (oldPathBreakdown[i][0] == '{' && !string.Equals(oldPathBreakdown[i], newPathBreakdown[i], StringComparison.OrdinalIgnoreCase))
+                {
+                    differences.Add($"{MakeApiName(item)} changed the parameter name `{oldPathBreakdown[i]}` to `{newPathBreakdown[i]}`");
+                }
+            }
         }
         
         // Detect more complex differences
@@ -221,7 +234,6 @@ public static class PatchNotesGenerator
         cl.Config.IgnoreCollectionOrder = true;
         cl.Config.MaxDifferences = int.MaxValue;
         var result = cl.Compare(item.Parameters.ToDictionary(pf => pf.Name), prevItem.Parameters.ToDictionary(pf => pf.Name));
-        var differences = new List<string>();
         foreach (var diff in result.Differences)
         {
             var p1 = diff.Object1 as ParameterField;
@@ -257,16 +269,5 @@ public static class PatchNotesGenerator
             }
         }
         return differences;
-    }
-
-    public static List<string> GetPathParameterList(string path)
-    {
-        List<string> results = new List<string>();
-        var regex = new Regex("\\{.*?\\}");
-        foreach (var match in regex.EnumerateMatches(path))
-        {
-            results.Add(path.Substring(match.Index + 1, match.Length - 2));
-        }
-        return results;
     }
 }

--- a/src/SdkGenerator/Diff/PatchNotesGenerator.cs
+++ b/src/SdkGenerator/Diff/PatchNotesGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using KellermanSoftware.CompareNetObjects;
 using SdkGenerator.Project;
 using SdkGenerator.Schema;
@@ -208,6 +209,14 @@ public static class PatchNotesGenerator
 
     private static List<string> GetEndpointChanges(GeneratorContext context, EndpointItem item, EndpointItem prevItem)
     {
+        // Detect parameter renames
+        var oldParameters = GetPathParameterList(prevItem.Path);
+        if (!item.Path.Equals(prevItem.Path, StringComparison.OrdinalIgnoreCase))
+        {
+            
+        }
+        
+        // Detect more complex differences
         var cl = new CompareLogic();
         cl.Config.IgnoreCollectionOrder = true;
         cl.Config.MaxDifferences = int.MaxValue;
@@ -248,5 +257,16 @@ public static class PatchNotesGenerator
             }
         }
         return differences;
+    }
+
+    public static List<string> GetPathParameterList(string path)
+    {
+        List<string> results = new List<string>();
+        var regex = new Regex("\\{.*?\\}");
+        foreach (var match in regex.EnumerateMatches(path))
+        {
+            results.Add(path.Substring(match.Index + 1, match.Length - 2));
+        }
+        return results;
     }
 }

--- a/src/SdkGenerator/Extensions.cs
+++ b/src/SdkGenerator/Extensions.cs
@@ -472,4 +472,32 @@ public static class Extensions
         }
         return s;
     }
+    
+    /// <summary>
+    /// Identify the elements of a Swagger URL path
+    /// </summary>
+    /// <remarks>
+    /// A path parameter appears surrounded by curly braces, e.g. `/api/{param}/action`.
+    /// This method breaks down the path into elements: `/api/`, `{param}`, and `/action`.
+    /// </remarks>
+    /// <param name="path">The path to examine.</param>
+    /// <returns>A list of parameter elements.</returns>
+    public static List<string> PathBreakdown(this string path)
+    {
+        List<string> results = new List<string>();
+        var regex = new Regex("\\{.*?\\}");
+        var p = 0;
+        foreach (var match in regex.EnumerateMatches(path))
+        {
+            results.Add(path.Substring(p, match.Index - p));
+            results.Add(path.Substring(match.Index, match.Length));
+            p = match.Index + match.Length;
+        }
+
+        if (path.Length > p)
+        {
+            results.Add(path.Substring(p));
+        }
+        return results;
+    }
 }

--- a/src/SdkGenerator/PatchNotes.md
+++ b/src/SdkGenerator/PatchNotes.md
@@ -1,3 +1,8 @@
+# 1.3.18
+April 22, 2026
+
+* Patch notes improvement: Detect path parameter renames
+
 # 1.3.17
 November 11, 2025
 

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -10,16 +10,15 @@
       easy-to-use markdown documentation or friendly software development kit libraries. Can be
       automated using Github Workflows.</Description>
     <PackageTags>SDK generator swagger openapi swashbuckle</PackageTags>
-    <Copyright>Copyright 2021 - 2025</Copyright>
+    <Copyright>Copyright 2021 - 2026</Copyright>
     <PackageReleaseNotes>
-        November 11, 2025
+      April 22, 2026
 
-        * Better patch notes generation - includes option to add markdown links
-        * Date categorization inside patch notes
+      * Patch notes improvement: Detect path parameter renames
     </PackageReleaseNotes>
     <PackageIcon>docs/icons-puzzle.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.3.17</Version>
+    <Version>1.3.18</Version>
     <Authors>Ted Spence</Authors>
     <!-- Project Url is filled in by sourcelink in the .NET 8 SDK, but you can add it explicitly via
     package -->
@@ -28,9 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference
-        Include="CommandLineParser"
-        Version="2.9.1" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />


### PR DESCRIPTION
We encountered a situation where the path parameter was renamed in an API change.  e.g. the old path was `/api/v1/{id}` and the new path was `/api/v1/{myId}`.  This isn't technically a breaking change, but the API patch notes made it seem really scary since it listed the change as "removing parameter id" and "adding parameter myId".

Let's fix.