### PR TITLE
Detect breaking changes vs deprecate-and-replace

### DIFF
--- a/SdkGenerator.Tests/ContextBuilder.cs
+++ b/SdkGenerator.Tests/ContextBuilder.cs
@@ -79,6 +79,19 @@ public class ContextBuilder
         return this;
     }
 
+    public ContextBuilder AddDeprecatedApi(string path, HttpMethod method, string category, string name)
+    {
+        _api.Endpoints.Add(new EndpointItem()
+        {
+            Path = path,
+            Method = method.ToString().ToLower(),
+            Category = category,
+            Name = name,
+            Deprecated = true,
+        });
+        return this;
+    }
+
     public ContextBuilder AddApi(string path, HttpMethod method, string category, string name)
     {
         _api.Endpoints.Add(new EndpointItem()
@@ -87,6 +100,7 @@ public class ContextBuilder
             Method = method.ToString().ToLower(),
             Category = category,
             Name = name,
+            Deprecated = false,
         });
         return this;
     }

--- a/SdkGenerator.Tests/PatchNotesTests.cs
+++ b/SdkGenerator.Tests/PatchNotesTests.cs
@@ -133,4 +133,34 @@ public class PatchNotesTests
         Assert.AreEqual("Test.DoSomethingMethod", diff.Renames[0].OldName);
         Assert.AreEqual("DoSomething", diff.Renames[0].Endpoint.Name);
     }
+
+    [TestMethod]
+    public void TestPathParameterExtraction()
+    {
+        var xyz = PatchNotesGenerator.GetPathParameterList("/api/{one}/test/{two}");
+        Assert.AreEqual(2, xyz.Count);
+        Assert.AreEqual("one", xyz[0]);
+        Assert.AreEqual("two", xyz[1]);
+    }
+    
+    [TestMethod]
+    public void PathParameterNameChange()
+    {
+        using var v1 = new ContextBuilder()
+            .AddApi("/test/api/{myId}/do-something", HttpMethod.Post, "Test", "DoSomethingMethod") 
+            .Build();
+        using var v2 = new ContextBuilder()
+            .AddApi("/test/api/{newId}/do-something", HttpMethod.Post, "Test", "DoSomethingMethod") 
+            .Build();
+        
+        var diff = PatchNotesGenerator.Compare(v1, v2);
+        Assert.AreEqual(0, diff.NewEndpoints.Count);
+        Assert.AreEqual(0, diff.DeprecatedEndpoints.Count);
+        Assert.AreEqual(1, diff.EndpointChanges.Count);
+        Assert.AreEqual(0, diff.SchemaChanges.Count);
+        Assert.AreEqual(0, diff.Renames.Count);
+        var change = diff.EndpointChanges.FirstOrDefault();
+        Assert.AreEqual("Test.DoSomethingMethod", change.Key);
+        Assert.AreEqual("Test.DoSomethingMethod changed the parameter name 'myId' to 'newId'", change.Value.FirstOrDefault());
+    }
 }

--- a/SdkGenerator.Tests/PatchNotesTests.cs
+++ b/SdkGenerator.Tests/PatchNotesTests.cs
@@ -137,10 +137,13 @@ public class PatchNotesTests
     [TestMethod]
     public void TestPathParameterExtraction()
     {
-        var xyz = PatchNotesGenerator.GetPathParameterList("/api/{one}/test/{two}");
-        Assert.AreEqual(2, xyz.Count);
-        Assert.AreEqual("one", xyz[0]);
-        Assert.AreEqual("two", xyz[1]);
+        var elements = "/api/{one}/test/{two}/action".PathBreakdown();
+        Assert.AreEqual(5, elements.Count);
+        Assert.AreEqual("/api/", elements[0]);
+        Assert.AreEqual("{one}", elements[1]);
+        Assert.AreEqual("/test/", elements[2]);
+        Assert.AreEqual("{two}", elements[3]);
+        Assert.AreEqual("/action", elements[4]);
     }
     
     [TestMethod]
@@ -161,6 +164,6 @@ public class PatchNotesTests
         Assert.AreEqual(0, diff.Renames.Count);
         var change = diff.EndpointChanges.FirstOrDefault();
         Assert.AreEqual("Test.DoSomethingMethod", change.Key);
-        Assert.AreEqual("Test.DoSomethingMethod changed the parameter name 'myId' to 'newId'", change.Value.FirstOrDefault());
+        Assert.AreEqual("Test.DoSomethingMethod changed the parameter name `{myId}` to `{newId}`", change.Value.FirstOrDefault());
     }
 }

--- a/SdkGenerator.Tests/PatchNotesTests.cs
+++ b/SdkGenerator.Tests/PatchNotesTests.cs
@@ -9,17 +9,21 @@ public class PatchNotesTests
     public void AddRemoveApis()
     {
         using var v1 = new ContextBuilder()
+            .AddApi("/api/test/retrieve", HttpMethod.Get, "test", "RetrieveTest")
             .Build();
 
         using var v2 = new ContextBuilder()
-            .AddRetrieveEndpoint("test", "RetrieveTest")
+            .AddDeprecatedApi("/api/test/retrieve", HttpMethod.Get, "test", "RetrieveTest")
             .Build();
-        
-        var diff = PatchNotesGenerator.Compare(v1, v2);
-        Assert.AreEqual(1, diff.NewEndpoints.Count);
 
-        var diff2 = PatchNotesGenerator.Compare(v2, v1);
-        Assert.AreEqual(1, diff2.DeprecatedEndpoints.Count);
+        var diff = PatchNotesGenerator.Compare(v1, v2);
+        Assert.AreEqual(0, diff.NewEndpoints.Count);
+        Assert.AreEqual(1, diff.DeprecatedEndpoints.Count);
+
+        // Try the same thing backwards - should show one new endpoint
+        var backwards = PatchNotesGenerator.Compare(v2, v1);
+        Assert.AreEqual(1, backwards.NewEndpoints.Count);
+        Assert.AreEqual(0, backwards.DeprecatedEndpoints.Count);
     }
     
     [TestMethod]

--- a/SdkGenerator.Tests/PatchNotesTests.cs
+++ b/SdkGenerator.Tests/PatchNotesTests.cs
@@ -166,4 +166,26 @@ public class PatchNotesTests
         Assert.AreEqual("Test.DoSomethingMethod", change.Key);
         Assert.AreEqual("Test.DoSomethingMethod changed the parameter name `{myId}` to `{newId}`", change.Value.FirstOrDefault());
     }
+    
+    [TestMethod]
+    public void DeprecateAndReplaceTest()
+    {
+        using var v1 = new ContextBuilder()
+            .AddApi("/test/api/{myId}/do-something", HttpMethod.Post, "Test", "DoSomethingMethod") 
+            .Build();
+        using var v2 = new ContextBuilder()
+            .AddDeprecatedApi("/test/api/{myId}/do-something", HttpMethod.Post, "Test", "DoSomethingMethod") 
+            .AddApi("/test/api/{newId}/do-something/{newParameter}", HttpMethod.Post, "Test", "DoSomethingMethod") 
+            .Build();
+        
+        var diff = PatchNotesGenerator.Compare(v1, v2);
+        Assert.AreEqual(0, diff.NewEndpoints.Count);
+        Assert.AreEqual(1, diff.DeprecatedEndpoints.Count);
+        Assert.AreEqual(1, diff.EndpointChanges.Count);
+        Assert.AreEqual(0, diff.SchemaChanges.Count);
+        Assert.AreEqual(0, diff.Renames.Count);
+        var change = diff.EndpointChanges.FirstOrDefault();
+        Assert.AreEqual("Test.DoSomethingMethod", change.Key);
+        Assert.AreEqual("Deprecated and replaced: The previous version of Test.DoSomethingMethod was deprecated and replaced with a new method.", change.Value.FirstOrDefault());
+    }
 }

--- a/SdkGenerator.Tests/SdkGenerator.Tests.csproj
+++ b/SdkGenerator.Tests/SdkGenerator.Tests.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/SdkGenerator/Diff/PatchNotesGenerator.cs
+++ b/src/SdkGenerator/Diff/PatchNotesGenerator.cs
@@ -209,11 +209,24 @@ public static class PatchNotesGenerator
 
     private static List<string> GetEndpointChanges(GeneratorContext context, EndpointItem item, EndpointItem prevItem)
     {
+        var differences = new List<string>();
+        
         // Detect parameter renames
-        var oldParameters = GetPathParameterList(prevItem.Path);
-        if (!item.Path.Equals(prevItem.Path, StringComparison.OrdinalIgnoreCase))
+        var oldPathBreakdown = prevItem.Path.PathBreakdown();
+        var newPathBreakdown = item.Path.PathBreakdown();
+        if (oldPathBreakdown.Count != newPathBreakdown.Count)
         {
-            
+            differences.Add($"Breaking change: {MakeApiName(item)} path changed from `{prevItem.Path}` to `{item.Path}`");
+        }
+        else
+        {
+            for (int i = 0; i < oldPathBreakdown.Count; i++)
+            {
+                if (oldPathBreakdown[i][0] == '{' && !string.Equals(oldPathBreakdown[i], newPathBreakdown[i], StringComparison.OrdinalIgnoreCase))
+                {
+                    differences.Add($"{MakeApiName(item)} changed the parameter name `{oldPathBreakdown[i]}` to `{newPathBreakdown[i]}`");
+                }
+            }
         }
         
         // Detect more complex differences
@@ -221,7 +234,6 @@ public static class PatchNotesGenerator
         cl.Config.IgnoreCollectionOrder = true;
         cl.Config.MaxDifferences = int.MaxValue;
         var result = cl.Compare(item.Parameters.ToDictionary(pf => pf.Name), prevItem.Parameters.ToDictionary(pf => pf.Name));
-        var differences = new List<string>();
         foreach (var diff in result.Differences)
         {
             var p1 = diff.Object1 as ParameterField;
@@ -257,16 +269,5 @@ public static class PatchNotesGenerator
             }
         }
         return differences;
-    }
-
-    public static List<string> GetPathParameterList(string path)
-    {
-        List<string> results = new List<string>();
-        var regex = new Regex("\\{.*?\\}");
-        foreach (var match in regex.EnumerateMatches(path))
-        {
-            results.Add(path.Substring(match.Index + 1, match.Length - 2));
-        }
-        return results;
     }
 }

--- a/src/SdkGenerator/Diff/PatchNotesGenerator.cs
+++ b/src/SdkGenerator/Diff/PatchNotesGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using KellermanSoftware.CompareNetObjects;
 using SdkGenerator.Project;
 using SdkGenerator.Schema;
@@ -208,6 +209,14 @@ public static class PatchNotesGenerator
 
     private static List<string> GetEndpointChanges(GeneratorContext context, EndpointItem item, EndpointItem prevItem)
     {
+        // Detect parameter renames
+        var oldParameters = GetPathParameterList(prevItem.Path);
+        if (!item.Path.Equals(prevItem.Path, StringComparison.OrdinalIgnoreCase))
+        {
+            
+        }
+        
+        // Detect more complex differences
         var cl = new CompareLogic();
         cl.Config.IgnoreCollectionOrder = true;
         cl.Config.MaxDifferences = int.MaxValue;
@@ -248,5 +257,16 @@ public static class PatchNotesGenerator
             }
         }
         return differences;
+    }
+
+    public static List<string> GetPathParameterList(string path)
+    {
+        List<string> results = new List<string>();
+        var regex = new Regex("\\{.*?\\}");
+        foreach (var match in regex.EnumerateMatches(path))
+        {
+            results.Add(path.Substring(match.Index + 1, match.Length - 2));
+        }
+        return results;
     }
 }

--- a/src/SdkGenerator/Diff/PatchNotesGenerator.cs
+++ b/src/SdkGenerator/Diff/PatchNotesGenerator.cs
@@ -197,6 +197,7 @@ public static class PatchNotesGenerator
             var wasPreviouslyAnEndpoint = previous.Api.Endpoints.Any(pe =>
                 string.Equals(pe.Category, deprecatedItem.Category, StringComparison.OrdinalIgnoreCase)
                 && string.Equals(pe.Name, deprecatedItem.Name, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(pe.Path, deprecatedItem.Path, StringComparison.OrdinalIgnoreCase)
                 && pe.Deprecated == false);
             if (!previous.IsIgnoredEndpoint(name, deprecatedItem.Path) && wasPreviouslyAnEndpoint)
             {

--- a/src/SdkGenerator/Diff/PatchNotesGenerator.cs
+++ b/src/SdkGenerator/Diff/PatchNotesGenerator.cs
@@ -135,7 +135,10 @@ public static class PatchNotesGenerator
                 nameToEndpoint[name] = [item];
             }
 
-            pathToName[item.Path + ":" + item.Method] = name;
+            if (!item.Deprecated)
+            {
+                pathToName[item.Path + ":" + item.Method] = name;
+            }
         }
 
         // Search for new or modified endpoints
@@ -168,7 +171,7 @@ public static class PatchNotesGenerator
             else
             {
                 nameToEndpoint.TryGetValue(name, out var prevItemList);
-                if (prevItemList == null)
+                if (prevItemList == null || prevItemList.All(pi => pi.Deprecated))
                 {
                     if (diff.NewEndpoints.ContainsKey(name))
                     {

--- a/src/SdkGenerator/Diff/PatchNotesGenerator.cs
+++ b/src/SdkGenerator/Diff/PatchNotesGenerator.cs
@@ -121,24 +121,26 @@ public static class PatchNotesGenerator
         var compared = new HashSet<string>();
         
         // Handle duplicate names, a common error in manually named APIs
-        var nameToEndpoint = new Dictionary<string, EndpointItem>();
+        var nameToEndpoint = new Dictionary<string, List<EndpointItem>>();
         var pathToName = new Dictionary<string, string>();
         foreach (var item in previous.Api.Endpoints)
         {
             var name = MakeApiName(item);
-            if (nameToEndpoint.ContainsKey(name))
+            if (nameToEndpoint.TryGetValue(name, out var prevItemList))
             {
-                current.LogError($"Duplicate API name in previous version of API: {name}");
+                prevItemList.Add(item);
+            }
+            else
+            {
+                nameToEndpoint[name] = [item];
             }
 
-            nameToEndpoint[name] = item;
             pathToName[item.Path + ":" + item.Method] = name;
         }
 
         // Search for new or modified endpoints
         foreach (var item in current.Api.Endpoints)
         {
-            EndpointItem? prevItem;
             var name = MakeApiName(item);
             
             // First check if the API was simply renamed
@@ -154,9 +156,9 @@ public static class PatchNotesGenerator
                 }
                 
                 // If endpoint had any meaningful changes, document those
-                if (nameToEndpoint.TryGetValue(prevName, out prevItem))
+                if (nameToEndpoint.TryGetValue(prevName, out var prevItemList))
                 {
-                    var endpointChanges = GetEndpointChanges(current, item, prevItem);
+                    var endpointChanges = GetEndpointChanges(current, item, prevItemList);
                     if (endpointChanges.Any())
                     {
                         diff.EndpointChanges[name] = endpointChanges;
@@ -165,8 +167,8 @@ public static class PatchNotesGenerator
             }
             else
             {
-                nameToEndpoint.TryGetValue(name, out prevItem);
-                if (prevItem == null)
+                nameToEndpoint.TryGetValue(name, out var prevItemList);
+                if (prevItemList == null)
                 {
                     if (diff.NewEndpoints.ContainsKey(name))
                     {
@@ -177,7 +179,7 @@ public static class PatchNotesGenerator
                 }
                 else
                 {
-                    var changes = GetEndpointChanges(current, item, prevItem);
+                    var changes = GetEndpointChanges(current, item, prevItemList);
                     if (changes.Any())
                     {
                         diff.EndpointChanges[name] = changes;
@@ -189,10 +191,14 @@ public static class PatchNotesGenerator
         }
 
         // Search for deprecated endpoints
-        foreach (var oldItem in previous.Api.Endpoints)
+        foreach (var deprecatedItem in current.Api.Endpoints.Where(e => e.Deprecated))
         {
-            var name = MakeApiName(oldItem);
-            if (!compared.Contains(name) && !previous.IsIgnoredEndpoint(name, oldItem.Path))
+            var name = MakeApiName(deprecatedItem);
+            var wasPreviouslyAnEndpoint = previous.Api.Endpoints.Any(pe =>
+                string.Equals(pe.Category, deprecatedItem.Category, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(pe.Name, deprecatedItem.Name, StringComparison.OrdinalIgnoreCase)
+                && pe.Deprecated == false);
+            if (!previous.IsIgnoredEndpoint(name, deprecatedItem.Path) && wasPreviouslyAnEndpoint)
             {
                 diff.DeprecatedEndpoints.Add(name);
             }
@@ -207,28 +213,56 @@ public static class PatchNotesGenerator
         return $"{item.Category}.{item.Name.ToProperCase()}";
     }
 
-    private static List<string> GetEndpointChanges(GeneratorContext context, EndpointItem item, EndpointItem prevItem)
+    private static List<string> GetEndpointChanges(GeneratorContext context, EndpointItem item, List<EndpointItem> prevItemList)
     {
-        var differences = new List<string>();
+        // If the new item is deprecated, report no changes - this is already covered by deprecation testing
+        if (item.Deprecated)
+        {
+            return [];
+        }
+
+        // Fetch the most recent non-deprecated endpoint matching this one
+        var prevItem = prevItemList.FirstOrDefault(pi => pi.Deprecated == false);
+        if (prevItem == null)
+        {
+            return [];
+        }
         
         // Detect parameter renames
-        var oldPathBreakdown = prevItem.Path.PathBreakdown();
-        var newPathBreakdown = item.Path.PathBreakdown();
-        if (oldPathBreakdown.Count != newPathBreakdown.Count)
+        var differences = new List<string>();
+        if (prevItem.Path != item.Path)
         {
-            differences.Add($"Breaking change: {MakeApiName(item)} path changed from `{prevItem.Path}` to `{item.Path}`");
-        }
-        else
-        {
-            for (int i = 0; i < oldPathBreakdown.Count; i++)
+            var oldPathBreakdown = prevItem.Path.PathBreakdown();
+            var newPathBreakdown = item.Path.PathBreakdown();
+            if (oldPathBreakdown.Count != newPathBreakdown.Count)
             {
-                if (oldPathBreakdown[i][0] == '{' && !string.Equals(oldPathBreakdown[i], newPathBreakdown[i], StringComparison.OrdinalIgnoreCase))
+                // Okay, now we need to determine if this is a "deprecate-and-replace" or if it's a breaking change
+                var isDeprecateAndReplace = context.Api.Endpoints.Any(e => e.Deprecated && e.Path == prevItem.Path);
+                if (isDeprecateAndReplace)
                 {
-                    differences.Add($"{MakeApiName(item)} changed the parameter name `{oldPathBreakdown[i]}` to `{newPathBreakdown[i]}`");
+                    differences.Add(
+                        $"Deprecated and replaced: The previous version of {MakeApiName(item)} was deprecated and replaced with a new method.");
+                }
+                else
+                {
+                    differences.Add(
+                        $"Breaking change: {MakeApiName(item)} path changed from `{prevItem.Path}` to `{item.Path}`");
+                }
+            }
+            else
+            {
+                for (int i = 0; i < oldPathBreakdown.Count; i++)
+                {
+                    if (oldPathBreakdown[i][0] == '{' && !string.Equals(oldPathBreakdown[i], newPathBreakdown[i],
+                            StringComparison.OrdinalIgnoreCase))
+                    {
+                        differences.Add(
+                            $"{MakeApiName(item)} changed the parameter name `{oldPathBreakdown[i]}` to `{newPathBreakdown[i]}`");
+                    }
                 }
             }
         }
-        
+
         // Detect more complex differences
         var cl = new CompareLogic();
         cl.Config.IgnoreCollectionOrder = true;

--- a/src/SdkGenerator/Extensions.cs
+++ b/src/SdkGenerator/Extensions.cs
@@ -472,4 +472,32 @@ public static class Extensions
         }
         return s;
     }
+    
+    /// <summary>
+    /// Identify the elements of a Swagger URL path
+    /// </summary>
+    /// <remarks>
+    /// A path parameter appears surrounded by curly braces, e.g. `/api/{param}/action`.
+    /// This method breaks down the path into elements: `/api/`, `{param}`, and `/action`.
+    /// </remarks>
+    /// <param name="path">The path to examine.</param>
+    /// <returns>A list of parameter elements.</returns>
+    public static List<string> PathBreakdown(this string path)
+    {
+        List<string> results = new List<string>();
+        var regex = new Regex("\\{.*?\\}");
+        var p = 0;
+        foreach (var match in regex.EnumerateMatches(path))
+        {
+            results.Add(path.Substring(p, match.Index - p));
+            results.Add(path.Substring(match.Index, match.Length));
+            p = match.Index + match.Length;
+        }
+
+        if (path.Length > p)
+        {
+            results.Add(path.Substring(p));
+        }
+        return results;
+    }
 }

--- a/src/SdkGenerator/Languages/CSharpSdk.cs
+++ b/src/SdkGenerator/Languages/CSharpSdk.cs
@@ -182,6 +182,11 @@ public class CSharpSdk : ILanguageSdk
 
         foreach (var item in context.Api.Schemas)
         {
+            if (item.Deprecated)
+            {
+                continue;
+            }
+            
             // Is this one of the handwritten schemas?  If so, skip it
             var handwritten = (context.Project.Csharp.HandwrittenClasses ?? Enumerable.Empty<string>()).ToList();
             handwritten.Add(context.Project.Csharp.ResponseClass);

--- a/src/SdkGenerator/PatchNotes.md
+++ b/src/SdkGenerator/PatchNotes.md
@@ -1,3 +1,8 @@
+# 1.3.18
+April 22, 2026
+
+* Patch notes improvement: Detect path parameter renames
+
 # 1.3.17
 November 11, 2025
 

--- a/src/SdkGenerator/PatchNotes.md
+++ b/src/SdkGenerator/PatchNotes.md
@@ -1,3 +1,10 @@
+**# 1.3.19
+August 12, 2026
+
+* Significant improvements to breaking change detection; added tests
+* Better handling of deprecated-and-replaced APIs
+* Improved patch notes handling for long lived documentation sites**
+
 # 1.3.18
 April 22, 2026
 

--- a/src/SdkGenerator/Program.cs
+++ b/src/SdkGenerator/Program.cs
@@ -257,6 +257,7 @@ public static class Program
         DateOnly? lastPrintedDate = null;
         
         // Sort them based on their version numbers and apply dates
+        int lastPrintedYear = currentYear;
         for (int i = versions.Count - 1; i >= 1; i--)
         {
             var date = dates.GetDateForVersion(versions[i].OfficialVersion);
@@ -271,13 +272,13 @@ public static class Program
             }
             else
             {
-                if (currentYear - 1 == date.Year)
+                if (currentYear - 1 >= date.Year)
                 {
-                    dateHeader = $"# Updates from {date.Year}" + Environment.NewLine + Environment.NewLine;
-                }
-                else if (currentYear - 2 > date.Year)
-                {
-                    dateHeader = $"# Older patches" + Environment.NewLine + Environment.NewLine;
+                    if (lastPrintedYear != date.Year)
+                    {
+                        dateHeader = $"# Updates from {date.Year}" + Environment.NewLine + Environment.NewLine;
+                        lastPrintedYear = date.Year;
+                    }
                 }
                 else if (lastPrintedDate == null || (date.Year == currentYear && date.Month != lastPrintedDate.Value.Month))
                 {

--- a/src/SdkGenerator/Schema/ApiSchema.cs
+++ b/src/SdkGenerator/Schema/ApiSchema.cs
@@ -29,6 +29,7 @@ public class SchemaItem
 {
     public string Name { get; set; } = string.Empty;
     public string DescriptionMarkdown { get; set; } = string.Empty;
+    public bool Deprecated { get; set; }
     public List<SchemaField> Fields { get; set; } = new();
 }
 

--- a/src/SdkGenerator/Schema/SchemaFactory.cs
+++ b/src/SdkGenerator/Schema/SchemaFactory.cs
@@ -24,7 +24,8 @@ public static class SchemaFactory
                 Name = jsonSchema.Name,
                 // Handle fields
                 Fields = new List<SchemaField>(),
-                DescriptionMarkdown = SafeGetPropString(jsonSchema.Value, "description")
+                DescriptionMarkdown = SafeGetPropString(jsonSchema.Value, "description"),
+                Deprecated = GetBooleanElement(jsonSchema.Value, "deprecated"),
             };
 
             foreach (var prop in schemaPropertiesElement.EnumerateObject())

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -10,16 +10,15 @@
       easy-to-use markdown documentation or friendly software development kit libraries. Can be
       automated using Github Workflows.</Description>
     <PackageTags>SDK generator swagger openapi swashbuckle</PackageTags>
-    <Copyright>Copyright 2021 - 2025</Copyright>
+    <Copyright>Copyright 2021 - 2026</Copyright>
     <PackageReleaseNotes>
-        November 11, 2025
+      April 22, 2026
 
-        * Better patch notes generation - includes option to add markdown links
-        * Date categorization inside patch notes
+      * Patch notes improvement: Detect path parameter renames
     </PackageReleaseNotes>
     <PackageIcon>docs/icons-puzzle.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.3.17</Version>
+    <Version>1.3.18</Version>
     <Authors>Ted Spence</Authors>
     <!-- Project Url is filled in by sourcelink in the .NET 8 SDK, but you can add it explicitly via
     package -->
@@ -28,9 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference
-        Include="CommandLineParser"
-        Version="2.9.1" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -12,13 +12,16 @@
     <PackageTags>SDK generator swagger openapi swashbuckle</PackageTags>
     <Copyright>Copyright 2021 - 2026</Copyright>
     <PackageReleaseNotes>
-      April 22, 2026
+      # 1.3.19
+      August 12, 2026
 
-      * Patch notes improvement: Detect path parameter renames
+      * Significant improvements to breaking change detection; added tests
+      * Better handling of deprecated-and-replaced APIs
+      * Improved patch notes handling for long lived documentation sites
     </PackageReleaseNotes>
     <PackageIcon>docs/icons-puzzle.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.3.18</Version>
+    <Version>1.3.19</Version>
     <Authors>Ted Spence</Authors>
     <!-- Project Url is filled in by sourcelink in the .NET 8 SDK, but you can add it explicitly via
     package -->

--- a/src/SdkGenerator/SdkGenerator.csproj
+++ b/src/SdkGenerator/SdkGenerator.csproj
@@ -29,10 +29,10 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.12.3" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="RestSharp" Version="112.1.0" />
-    <PackageReference Include="Scriban" Version="6.4.0" />
+    <PackageReference Include="RestSharp" Version="114.0.0" />
+    <PackageReference Include="Scriban" Version="7.2.6" />
     <PackageReference Include="Semver" Version="3.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
We're doing a lot more work with patch notes. Let's correctly handle deprecation-and-replace cases.